### PR TITLE
Build from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ COPY config/default ./config/default
 COPY data ./data
 COPY inst ./inst
 
+ENV BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE
+
 # R dependencies
-RUN R -e 'install.packages(c("BiocManager","remotes"))'
 RUN R -e 'remotes::install_github(repo = "taxonomicallyinformedannotation/tima-r", upgrade = "always", build_vignettes = FALSE)'
 
 COPY . ./


### PR DESCRIPTION
- Adding `BIOCONDUCTOR_USE_CONTAINER_REPOSITORY=FALSE` to avoid using binary repository (to make `arm64` pass), re https://github.com/Bioconductor/bioconductor_docker/issues/64
- BiocManager is included and versioned with the container image. Overwriting BiocManager could lead to mismatches so I am also suggesting removing it